### PR TITLE
Fix guard condition on toupper call

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -714,7 +714,7 @@ int main(int argc, const char *argv[])
             int key = Renderer::keyEventBuffer[i].scanCode;
             mShaderEditor.KeyDown(
               // Scintilla expects scancode, hence uppercase letters
-              isalpha(key) ? toupper(key) : key,
+              (key >= 0 && key < 0x80) ? toupper(key) : key,
               Renderer::keyEventBuffer[i].shift,
               Renderer::keyEventBuffer[i].ctrl,
               Renderer::keyEventBuffer[i].alt,


### PR DESCRIPTION
Calling isalpha or toupper with a value outside of the ascii range (nor EOF) results in undefined behavior. The function `isalpha` cannot be used to distinguish such cases. Replace this by a simple test on the ascii range.