### PR TITLE
Add macros for Fn keys

### DIFF
--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -1,6 +1,20 @@
 #include <Platform.h>
 #include "NetworkSettings.h"
 
+/* custom scancode for Fn keys */
+#define KEY_F1 282
+#define KEY_F2 283
+#define KEY_F3 284
+#define KEY_F4 285
+#define KEY_F5 286
+#define KEY_F6 287
+#define KEY_F7 288
+#define KEY_F8 289
+#define KEY_F9 290
+#define KEY_F10 291
+#define KEY_F11 292
+#define KEY_F12 293
+
 typedef enum {
   RENDERER_WINDOWMODE_WINDOWED = 0,
   RENDERER_WINDOWMODE_FULLSCREEN,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -660,21 +660,21 @@ int main(int argc, const char *argv[])
 	Renderer::keyEventBuffer[i].scanCode = key;
       }
 
-      if (Renderer::keyEventBuffer[i].scanCode == 283) // F2
+      if (key == KEY_F2)
       {
          bTexPreviewVisible = !bTexPreviewVisible;
          needEditorUpdate = true;
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 284) // F3
+      else if (key == KEY_F3)
       {
         bGrabberFollowCaret = !bGrabberFollowCaret;
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 285) // F4
+      else if (key == KEY_F4)
       {
         // adjust offset so that time restarts from 0
         shaderTimeOffset = -time;
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 286 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'R')) // F5
+      else if (key == KEY_F5 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'R'))
       {
         mShaderEditor.GetText(szShader,65535);
 
@@ -707,7 +707,7 @@ int main(int argc, const char *argv[])
           mDebugOutput.SetText( szError );
         }
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 292 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'F')) // F11 or Ctrl/Cmd-f
+      else if (key == KEY_F11 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'F'))
       {
         bShowGui = !bShowGui;
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -653,6 +653,13 @@ int main(int argc, const char *argv[])
 
     for(int i=0; i<Renderer::keyEventBufferCount; i++)
     {
+      int key = Renderer::keyEventBuffer[i].scanCode;
+
+      if (key >= 'a' && key <= 'z') {
+	key = toupper(key);
+	Renderer::keyEventBuffer[i].scanCode = key;
+      }
+
       if (Renderer::keyEventBuffer[i].scanCode == 283) // F2
       {
          bTexPreviewVisible = !bTexPreviewVisible;
@@ -667,7 +674,7 @@ int main(int argc, const char *argv[])
         // adjust offset so that time restarts from 0
         shaderTimeOffset = -time;
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 286 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'r')) // F5
+      else if (Renderer::keyEventBuffer[i].scanCode == 286 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'R')) // F5
       {
         mShaderEditor.GetText(szShader,65535);
 
@@ -700,7 +707,7 @@ int main(int argc, const char *argv[])
           mDebugOutput.SetText( szError );
         }
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 292 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'f')) // F11 or Ctrl/Cmd-f  
+      else if (Renderer::keyEventBuffer[i].scanCode == 292 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'F')) // F11 or Ctrl/Cmd-f
       {
         bShowGui = !bShowGui;
       }
@@ -711,10 +718,8 @@ int main(int argc, const char *argv[])
           bool consumed = false;
           if (Renderer::keyEventBuffer[i].scanCode)
           {
-            int key = Renderer::keyEventBuffer[i].scanCode;
             mShaderEditor.KeyDown(
-              // Scintilla expects scancode, hence uppercase letters
-              (key >= 0 && key < 0x80) ? toupper(key) : key,
+              Renderer::keyEventBuffer[i].scanCode,
               Renderer::keyEventBuffer[i].shift,
               Renderer::keyEventBuffer[i].ctrl,
               Renderer::keyEventBuffer[i].alt,

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -519,18 +519,18 @@ namespace Renderer
 //           case GLFW_KEY_LEFTBRACKET:  sciKey = '[';           break;
 //           case GLFW_KEY_BACKSLASH:    sciKey = '\\';          break;
 //           case GLFW_KEY_RIGHTBRACKET: sciKey = ']';           break;
-        case GLFW_KEY_F1:           sciKey = 282;           break;
-        case GLFW_KEY_F2:           sciKey = 283;           break;
-        case GLFW_KEY_F3:           sciKey = 284;           break;
-        case GLFW_KEY_F4:           sciKey = 285;           break;
-        case GLFW_KEY_F5:           sciKey = 286;           break;
-        case GLFW_KEY_F6:           sciKey = 287;           break;
-        case GLFW_KEY_F7:           sciKey = 288;           break;
-        case GLFW_KEY_F8:           sciKey = 289;           break;
-        case GLFW_KEY_F9:           sciKey = 290;           break;
-        case GLFW_KEY_F10:          sciKey = 291;           break;
-        case GLFW_KEY_F11:          sciKey = 292;           break;
-        case GLFW_KEY_F12:          sciKey = 293;           break;
+        case GLFW_KEY_F1:           sciKey = KEY_F1;           break;
+        case GLFW_KEY_F2:           sciKey = KEY_F2;           break;
+        case GLFW_KEY_F3:           sciKey = KEY_F3;           break;
+        case GLFW_KEY_F4:           sciKey = KEY_F4;           break;
+        case GLFW_KEY_F5:           sciKey = KEY_F5;           break;
+        case GLFW_KEY_F6:           sciKey = KEY_F6;           break;
+        case GLFW_KEY_F7:           sciKey = KEY_F7;           break;
+        case GLFW_KEY_F8:           sciKey = KEY_F8;           break;
+        case GLFW_KEY_F9:           sciKey = KEY_F9;           break;
+        case GLFW_KEY_F10:          sciKey = KEY_F10;           break;
+        case GLFW_KEY_F11:          sciKey = KEY_F11;           break;
+        case GLFW_KEY_F12:          sciKey = KEY_F12;           break;
         case GLFW_KEY_LEFT_SHIFT:
         case GLFW_KEY_RIGHT_SHIFT:
         case GLFW_KEY_LEFT_ALT:

--- a/src/platform_osx/TouchBar.mm
+++ b/src/platform_osx/TouchBar.mm
@@ -123,13 +123,13 @@ typedef enum {
     Renderer::keyEventBuffer[Renderer::keyEventBufferCount].character = 0;
     switch (command) {
         case toggleGUI:
-            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 292;
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = KEY_F11;
             break;
         case toggleTextures:
-            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 283;
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = KEY_F2;
             break;
         case compile:
-            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 286;
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = KEY_F5;
             break;
     }
     Renderer::keyEventBufferCount++;

--- a/src/platform_w32_dx11/Renderer.cpp
+++ b/src/platform_w32_dx11/Renderer.cpp
@@ -219,11 +219,11 @@ namespace Renderer
 //         case VK_LEFTBRACKET:  sciKey = '[';           break;
 //         case VK_BACKSLASH:    sciKey = '\\';          break;
 //         case VK_RIGHTBRACKET: sciKey = ']';           break;
-        case VK_F2:         sciKey = 283;      break;
-        case VK_F3:         sciKey = 284;      break;
-        case VK_F4:         sciKey = 285;      break;
-        case VK_F5:         sciKey = 286;      break;
-        case VK_F11:        sciKey = 292;      break;
+        case VK_F2:         sciKey = KEY_F2;      break;
+        case VK_F3:         sciKey = KEY_F3;      break;
+        case VK_F4:         sciKey = KEY_F4;      break;
+        case VK_F5:         sciKey = KEY_F5;      break;
+        case VK_F11:        sciKey = KEY_F11;      break;
         case VK_SHIFT:
         case VK_LSHIFT:
         case VK_RSHIFT:

--- a/src/platform_w32_dx9/Renderer.cpp
+++ b/src/platform_w32_dx9/Renderer.cpp
@@ -223,11 +223,11 @@ namespace Renderer
 //         case VK_LEFTBRACKET:  sciKey = '[';           break;
 //         case VK_BACKSLASH:    sciKey = '\\';          break;
 //         case VK_RIGHTBRACKET: sciKey = ']';           break;
-        case VK_F2:         sciKey = 283;      break;
-        case VK_F3:         sciKey = 284;      break;
-        case VK_F4:         sciKey = 285;      break;
-        case VK_F5:         sciKey = 286;      break;
-        case VK_F11:        sciKey = 292;      break;
+        case VK_F2:         sciKey = KEY_F2;      break;
+        case VK_F3:         sciKey = KEY_F3;      break;
+        case VK_F4:         sciKey = KEY_F4;      break;
+        case VK_F5:         sciKey = KEY_F5;      break;
+        case VK_F11:        sciKey = KEY_F11;      break;
         case VK_SHIFT:
         case VK_LSHIFT:
         case VK_RSHIFT:


### PR DESCRIPTION
Functions key input event where using custom scancode value,
simply add macros to have the name of the function key instead
of an int.

---

requires #17 